### PR TITLE
Is86 turbolinks

### DIFF
--- a/app/javascript/packs/items.coffee
+++ b/app/javascript/packs/items.coffee
@@ -5,7 +5,5 @@ import locale from 'element-ui/lib/locale/lang/en'
 Vue.use(ElementUI, { locale })
 items = new Vue({
 	el: '[data-behavior="vue"]',
-	components: {
-		'items-view': ItemsView
-	},
+	components: { 'items': ItemsView },
 })

--- a/app/javascript/packs/receipts.coffee
+++ b/app/javascript/packs/receipts.coffee
@@ -5,7 +5,5 @@ import locale from 'element-ui/lib/locale/lang/en'
 Vue.use(ElementUI, { locale })
 receipts = new Vue({
 	el: '[data-behavior="vue"]',
-	components: {
-		'receipts-view': ReceiptsView
-	},
+	components: { 'receipts': ReceiptsView },
 })

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	</head>
 	<body>
-		<%= yield %>
+		<div data-behavior="vue">
+			<%= yield %>
+		</div>
 	</body>
 </html>

--- a/app/views/receipts/index.html.erb
+++ b/app/views/receipts/index.html.erb
@@ -1,4 +1,2 @@
-<div data-behavior="vue">
-	<receipts-view></receipts-view>
-</div>
+<receipts></receipts>
 <%= javascript_pack_tag 'receipts' %>

--- a/app/views/receipts/show.html.erb
+++ b/app/views/receipts/show.html.erb
@@ -1,4 +1,2 @@
-<div data-behavior="vue">
-	<items-view></items-view>
-</div>
+<items></items>
 <%= javascript_pack_tag 'items' %>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "jquery": "^3.3.1",
     "vue": "^2.5.16",
     "vue-loader": "14.2.2",
-    "vue-template-compiler": "^2.5.16",
-    "vue-turbolinks": "^2.0.3"
+    "vue-template-compiler": "^2.5.16"
   },
   "devDependencies": {
     "coffee-script": "^1.12.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5888,13 +5888,7 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue-turbolinks@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/vue-turbolinks/-/vue-turbolinks-2.0.3.tgz#4600d4c4f2e6a35cf5f93636c9d5c20285bc2cd7"
-  dependencies:
-    vue "^2.2.4"
-
-vue@^2.2.4, vue@^2.5.16:
+vue@^2.5.16:
   version "2.5.16"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.16.tgz#07edb75e8412aaeed871ebafa99f4672584a0085"
 


### PR DESCRIPTION
Closes #86 

Doesn't implement turbolinks, it was causing some loading issues rendering content and seemed a bit overkill for a nearly SPA site managed by Vue.